### PR TITLE
Add invoice parser web application

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Many of these issues could be resolved by investigating alternative detection me
 * [Counting Cars Open CV (Dan Masek)](https://stackoverflow.com/a/36274515)
 * [Speed Tracking (Ian Dees)](https://github.com/iandees/speedtrack)
 * [SDC Vehicle Lane Detection (Max Ritter)](https://github.com/maxritter/SDC-Vehicle-Lane-Detection)
+
+---
+
+## Invoice Parser Web App
+
+A small Flask application for uploading invoices (PDF or image) and parsing them using OpenAI GPT.
+See [invoice_app/README.md](invoice_app/README.md) for setup and usage instructions.

--- a/invoice_app/.env.example
+++ b/invoice_app/.env.example
@@ -1,3 +1,3 @@
 # Rename this file to .env and add your OpenAI API key
-OPENAI_API_KEY=your_openai_key_here
+OPENAI_API_KEY=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
 SECRET_KEY=change_me

--- a/invoice_app/.env.example
+++ b/invoice_app/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and add your OpenAI API key
+OPENAI_API_KEY=your_openai_key_here
+SECRET_KEY=change_me

--- a/invoice_app/README.md
+++ b/invoice_app/README.md
@@ -1,0 +1,25 @@
+# Invoice Parser Web App
+
+This Flask application allows you to upload a PDF or image (PNG, JPG) invoice and returns parsed data using the OpenAI GPT API. The app extracts text from the uploaded file, sends it to OpenAI for parsing and displays the suggested accounting entries based on `predkontace.json`.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a `.env` file or export the API key in your environment:
+
+```
+OPENAI_API_KEY=your_openai_key_here
+```
+
+3. Run the application:
+
+```bash
+python invoice_app/app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/invoice_app/app.py
+++ b/invoice_app/app.py
@@ -1,0 +1,135 @@
+import os
+import json
+from flask import Flask, render_template, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
+from PyPDF2 import PdfReader
+from PIL import Image
+import pytesseract
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'secret!')
+ALLOWED_EXTENSIONS = {'pdf', 'png', 'jpg', 'jpeg'}
+
+PREDKONTACE_PATH = os.path.join(os.path.dirname(__file__), 'predkontace.json')
+with open(PREDKONTACE_PATH, 'r', encoding='utf-8') as f:
+    PREDKONTACE = json.load(f)
+
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+SYSTEM_PROMPT = (
+    "Jsi účetní asistent. Z poskytnutého textu dokladu extrahuj následující pole"
+    ": ico, date, base, vat, currency. Vrať čisté JSON bez vysvětlení ve tvaru "
+    "{\"ico\":..., \"date\":..., \"base\":..., \"vat\":..., \"currency\":..., \"raw_text\":...}"
+)
+
+
+def allowed_file(filename: str) -> bool:
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def extract_text(file_storage) -> str:
+    filename = file_storage.filename
+    ext = filename.rsplit('.', 1)[1].lower()
+    if ext == 'pdf':
+        reader = PdfReader(file_storage)
+        text = "\n".join(page.extract_text() or '' for page in reader.pages)
+    else:
+        image = Image.open(file_storage)
+        text = pytesseract.image_to_string(image, lang='ces+eng')
+    return text
+
+
+def parse_amount(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    value = str(value).replace(' ', '').replace(',', '.')
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def call_openai(text: str) -> dict:
+    if not openai.api_key:
+        raise RuntimeError('OpenAI API key not configured')
+    response = openai.ChatCompletion.create(
+        model='gpt-3.5-turbo',
+        messages=[
+            {'role': 'system', 'content': SYSTEM_PROMPT},
+            {'role': 'user', 'content': text}
+        ],
+        temperature=0
+    )
+    content = response['choices'][0]['message']['content']
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        raise ValueError('Invalid response from OpenAI')
+    return data
+
+
+def build_accounting_suggestions(data: dict) -> list:
+    suggestions = []
+    base = parse_amount(data.get('base'))
+    vat = parse_amount(data.get('vat'))
+    if base is not None:
+        cfg = PREDKONTACE.get('zaklad')
+        suggestions.append({
+            'account': cfg['account'],
+            'debit': base,
+            'credit': 0.0,
+            'description': cfg['description']
+        })
+    if vat is not None:
+        cfg = PREDKONTACE.get('dph')
+        suggestions.append({
+            'account': cfg['account'],
+            'debit': vat,
+            'credit': 0.0,
+            'description': cfg['description']
+        })
+    if base is not None or vat is not None:
+        total = (base or 0) + (vat or 0)
+        cfg = PREDKONTACE.get('payment')
+        suggestions.append({
+            'account': cfg['account'],
+            'debit': 0.0,
+            'credit': total,
+            'description': cfg['description']
+        })
+    return suggestions
+
+
+@app.route('/', methods=['GET', 'POST'])
+def upload_file():
+    if request.method == 'POST':
+        if 'file' not in request.files:
+            flash('No file part')
+            return redirect(request.url)
+        file = request.files['file']
+        if file.filename == '':
+            flash('No selected file')
+            return redirect(request.url)
+        if not allowed_file(file.filename):
+            flash('Unsupported file type')
+            return redirect(request.url)
+        try:
+            text = extract_text(file)
+            gpt_data = call_openai(text)
+            gpt_data['raw_text'] = text
+            gpt_data['accounting_suggestions'] = build_accounting_suggestions(gpt_data)
+            return render_template('result.html', data=gpt_data)
+        except Exception as e:
+            flash(str(e))
+            return redirect(request.url)
+    return render_template('upload.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/invoice_app/predkontace.json
+++ b/invoice_app/predkontace.json
@@ -1,0 +1,5 @@
+{
+  "zaklad": {"account": "321", "description": "Základ DPH"},
+  "dph": {"account": "343", "description": "DPH 21%"},
+  "payment": {"account": "221", "description": "Úhrada dodavateli"}
+}

--- a/invoice_app/templates/result.html
+++ b/invoice_app/templates/result.html
@@ -1,41 +1,98 @@
+/* upload.html */
 <!doctype html>
-<html lang="en">
+<html lang="cs">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <title>Výsledky</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Nahrání dokladu</title>
 </head>
-<body class="p-4">
-  <div class="container">
-    <h1 class="mb-4">Výsledek zpracování</h1>
-    <h3>Data z dokladu</h3>
-    <table class="table table-bordered">
-      <tr><th>IČO</th><td>{{ data.ico }}</td></tr>
-      <tr><th>Datum vystavení</th><td>{{ data.date }}</td></tr>
-      <tr><th>Základ daně</th><td>{{ data.base }}</td></tr>
-      <tr><th>DPH</th><td>{{ data.vat }}</td></tr>
-      <tr><th>Měna</th><td>{{ data.currency }}</td></tr>
-    </table>
-    <h3>Účetní zápisy</h3>
+<body>
+  <div class="container mt-5">
+    <h1>Nahrát doklad</h1>
+    <form method="post" action="/" enctype="multipart/form-data" id="uploadForm">
+      <div class="form-group">
+        <label for="file">Zvolte soubor (PDF, JPG, PNG):</label>
+        <input type="file" class="form-control-file" id="file" name="file" accept=".pdf,image/*" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Odeslat</button>
+    </form>
+    <div id="alertPlaceholder"></div>
+  </div>
+
+  <script>
+    document.getElementById('uploadForm').addEventListener('submit', function(e) {
+      var fileInput = document.getElementById('file');
+      if (!fileInput.value) {
+        e.preventDefault();
+        showAlert('Prosím vyberte soubor před odesláním.', 'danger');
+      }
+    });
+
+    function showAlert(message, type) {
+      var wrapper = document.createElement('div');
+      wrapper.innerHTML =
+        '<div class="alert alert-' + type + ' alert-dismissible" role="alert">' +
+          '<span>' + message + '</span>' +
+          '<button type="button" class="close" data-dismiss="alert" aria-label="Zavřít">' +
+            '<span aria-hidden="true">&times;</span>' +
+          '</button>' +
+        '</div>';
+      document.getElementById('alertPlaceholder').append(wrapper);
+    }
+  </script>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+
+/* result.html */
+<!doctype html>
+<html lang="cs">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Výsledek zpracování</title>
+</head>
+<body>
+  <div class="container mt-5">
+    <h1>Výsledek zpracování dokladu</h1>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p><strong>IČO:</strong> {{ data.ico }}</p>
+        <p><strong>Datum:</strong> {{ data.date }}</p>
+        <p><strong>Základ:</strong> {{ data.base }}</p>
+        <p><strong>DPH:</strong> {{ data.vat }}</p>
+        <p><strong>Měna:</strong> {{ data.currency }}</p>
+        <p><strong>Text dokladu:</strong></p>
+        <pre>{{ data.raw_text }}</pre>
+      </div>
+    </div>
+    <h2>Navrhované účetní zápisy</h2>
     <table class="table table-striped">
       <thead>
-        <tr><th>Účet</th><th>MD</th><th>D</th><th>Popis</th></tr>
+        <tr>
+          <th>Účet</th>
+          <th>MD</th>
+          <th>D</th>
+          <th>Popis</th>
+        </tr>
       </thead>
       <tbody>
-        {% for row in data.accounting_suggestions %}
+        {% for entry in data.accounting_suggestions %}
         <tr>
-          <td>{{ row.account }}</td>
-          <td>{{ '%.2f'|format(row.debit) }}</td>
-          <td>{{ '%.2f'|format(row.credit) }}</td>
-          <td>{{ row.description }}</td>
+          <td>{{ entry.account }}</td>
+          <td>{{ entry.debit }}</td>
+          <td>{{ entry.credit }}</td>
+          <td>{{ entry.description }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
-    <h3>Text dokladu</h3>
-    <pre class="bg-light p-3">{{ data.raw_text }}</pre>
-    <a href="{{ url_for('upload_file') }}" class="btn btn-secondary">Zpět</a>
+    <a href="/" class="btn btn-secondary mt-3">Nahrát nový doklad</a>
   </div>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/invoice_app/templates/result.html
+++ b/invoice_app/templates/result.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Výsledky</title>
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Výsledek zpracování</h1>
+    <h3>Data z dokladu</h3>
+    <table class="table table-bordered">
+      <tr><th>IČO</th><td>{{ data.ico }}</td></tr>
+      <tr><th>Datum vystavení</th><td>{{ data.date }}</td></tr>
+      <tr><th>Základ daně</th><td>{{ data.base }}</td></tr>
+      <tr><th>DPH</th><td>{{ data.vat }}</td></tr>
+      <tr><th>Měna</th><td>{{ data.currency }}</td></tr>
+    </table>
+    <h3>Účetní zápisy</h3>
+    <table class="table table-striped">
+      <thead>
+        <tr><th>Účet</th><th>MD</th><th>D</th><th>Popis</th></tr>
+      </thead>
+      <tbody>
+        {% for row in data.accounting_suggestions %}
+        <tr>
+          <td>{{ row.account }}</td>
+          <td>{{ '%.2f'|format(row.debit) }}</td>
+          <td>{{ '%.2f'|format(row.credit) }}</td>
+          <td>{{ row.description }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <h3>Text dokladu</h3>
+    <pre class="bg-light p-3">{{ data.raw_text }}</pre>
+    <a href="{{ url_for('upload_file') }}" class="btn btn-secondary">Zpět</a>
+  </div>
+</body>
+</html>

--- a/invoice_app/templates/upload.html
+++ b/invoice_app/templates/upload.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Nahrát doklad</title>
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Nahrát doklad</h1>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="alert alert-danger">
+          {{ messages[0] }}
+        </div>
+      {% endif %}
+    {% endwith %}
+    <form method="post" enctype="multipart/form-data">
+      <div class="mb-3">
+        <input class="form-control" type="file" name="file" accept=".pdf,.png,.jpg,.jpeg" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Odeslat</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=2.0
+PyPDF2
+pytesseract
+pillow
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- create new `invoice_app` Flask project with file upload and GPT integration
- store účetní mappings in `predkontace.json`
- add HTML templates for upload form and results
- document usage in new README
- expose setup instructions in repository README
- list required packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874d38de9dc832192dd15b3981411dd